### PR TITLE
Added limit-filesize option to avoid duplcation issues

### DIFF
--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -80,6 +80,16 @@ void main(List<String> arguments) async {
       help: "Set creation time equal to the last "
       'modification date at the end of the program.'
       'Only Windows supported'
+    )
+    ..addOption('limit-filesize',
+        help: 'Enforces a maximum size of $maxFileSizeInMB MB per file to create hash for systems with low RAM.',
+        allowed: ['0', '1', '2'],
+        allowedHelp: {
+          '0': 'No limit',
+          '1': 'Use alternate hashing for files > $maxFileSizeInMB MB. May skip moving nearly identical files',
+          '2': 'Skip hashing for files > $maxFileSizeInMB MB. May produce duplicates in shortcut mode',
+        },
+        defaultsTo: '0',
     );
   final args = <String, dynamic>{};
   try {
@@ -136,6 +146,8 @@ void main(List<String> arguments) async {
       args['update-creation-time'] = await interactive.askChangeCreationTime();
       print('');
     }
+    args['limit-filesize'] = await interactive.askIfLimitFileSize();
+    print('');
 
     // @Deprecated('Interactive unzipping is suspended for now!')
     // // calculate approx space required for everything
@@ -152,6 +164,31 @@ void main(List<String> arguments) async {
     // await interactive.unzip(zips, unzipDir);
     // print('');
   }
+  
+  num limitFileSizeOpt;
+  if (args['limit-filesize'] is num ) {
+    limitFileSizeOpt = args['limit-filesize'];
+  }
+  else {
+    limitFileSizeOpt = num.parse(args['limit-filesize']);  }
+  switch (limitFileSizeOpt) {
+    case 0:
+      enforceMaxFileSize = false;
+      alternateHash = false;
+      break;
+    case 1:
+      enforceMaxFileSize = false;
+      alternateHash = true;
+      break;
+    case 2:
+      enforceMaxFileSize = true;
+      alternateHash = false;
+      break;
+    default:
+      enforceMaxFileSize = false;
+      alternateHash = false;
+  }
+
 
   // elastic list of extractors - can add/remove with cli flags
   // those are in order of reliability -

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -314,6 +314,36 @@ Future<bool> askChangeCreationTime() async {
   }
 }
 
+Future<num> askIfLimitFileSize() async {
+  print('If you have large fileson low-RAM systems, '
+      'you can limit hashing for files over $maxFileSizeInMB MB. '
+      'Skipping hash generation may lead to duplicate copies in shortcut mode '
+      'but it will prevent crashes on very large files. \nIf you have '
+      'issues try options 1 or 2.');
+  print('Do you want to limit the file size for hash generation?');
+  print('[0] (default) - No limit; hash all files');
+  print('[1] - Alternate hash for >$maxFileSizeInMB MB files; may skip moving nearly identical files (e.g. with only minor mid-file changes)');
+  print('[2] - Skip hashing for files > $maxFileSizeInMB MB; may produce duplicate copies in the output folder in shortcut mode');
+    
+  final answer = await askForInt();
+  switch (answer) {
+    case '0':
+    case '':
+      print('No limit - hashes will be generated for all files');
+      return 0;
+    case '1':
+      print('Will use alternate hashing for files > $maxFileSizeInMB MB');
+      return 1;
+    case '2':
+      print('Will skip hashing for files > $maxFileSizeInMB MB');
+      
+      return 2;
+    default:
+      error('Invalid answer - try again');
+      return askIfLimitFileSize();
+  }
+}
+
 /// Checks free space on disk and notifies user accordingly
 @Deprecated('Interactive unzipping is suspended for now!')
 Future<void> freeSpaceNotice(int required, Directory dir) async {

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -315,7 +315,7 @@ Future<bool> askChangeCreationTime() async {
 }
 
 Future<num> askIfLimitFileSize() async {
-  print('If you have large fileson low-RAM systems, '
+  print('If you have large files on low-RAM systems, '
       'you can limit hashing for files over $maxFileSizeInMB MB. '
       'Skipping hash generation may lead to duplicate copies in shortcut mode '
       'but it will prevent crashes on very large files. \nIf you have '

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -17,6 +17,10 @@ const version = '3.4.3';
 
 /// max file size to read for exif/hash/anything
 const maxFileSize = 64 * 1024 * 1024;
+const maxFileSizeInMB = maxFileSize/(1024 * 1024);
+
+bool enforceMaxFileSize = false;
+bool alternateHash = false;
 
 /// convenient print for errors
 void error(Object? object) => stderr.write('$object\n');


### PR DESCRIPTION
Based on v4.0.0 from Xentraxx (https://github.com/Xentraxx/GooglePhotosTakeoutHelper/tree/v4.0.1),
I have added a new option (limit-filesize) that enables GPTH to hash larger videos and images, avoiding file duplication issues in `shortcut modes`. Default is no limitation.