### PR TITLE
Add GPS metadata injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,6 @@ https://github.com/vHanda/google-keep-exporter
 Yeah, the whole thing got re-written in Dart, and now it's way more stable and faster. If you still want Python for some reason, check out v2.x - in releases/tags
 
 ### TODO (Pull Requests welcome):
-- [ ] GPS data: from JSON to Exif - ~~Thank you @DalenW 💖~~ still thank you, but it is now missing in the Dart version
+- [x] GPS data: from JSON to Exif
 - [ ] Writing data from `.json`s back to `EXIF` data
 - [x] Some way to handle albums - THANK YOU @bitsondatadev 😘 🎉 💃

--- a/lib/date_extractors/json_extractor.dart
+++ b/lib/date_extractors/json_extractor.dart
@@ -9,7 +9,7 @@ import 'package:unorm_dart/unorm_dart.dart' as unorm;
 
 /// Finds corresponding json file with info and gets 'photoTakenTime' from it
 Future<DateTime?> jsonExtractor(File file, {bool tryhard = false}) async {
-  final jsonFile = await _jsonForFile(file, tryhard: tryhard);
+  final jsonFile = await jsonFileFor(file, tryhard: tryhard);
   if (jsonFile == null) return null;
   try {
     final data = jsonDecode(await jsonFile.readAsString());
@@ -29,7 +29,7 @@ Future<DateTime?> jsonExtractor(File file, {bool tryhard = false}) async {
   }
 }
 
-Future<File?> _jsonForFile(File file, {required bool tryhard}) async {
+Future<File?> jsonFileFor(File file, {required bool tryhard}) async {
   final dir = Directory(p.dirname(file.path));
   var name = p.basename(file.path);
   // will try all methods to strip name to find json

--- a/lib/gps_writer.dart
+++ b/lib/gps_writer.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:image/image.dart';
+
+import 'date_extractors/json_extractor.dart';
+
+/// Writes GPS coordinates from the sidecar JSON into the image's EXIF data.
+/// If the JSON file doesn't contain GPS information, nothing is changed.
+Future<void> writeGpsFromJson(File image, {bool tryHard = false}) async {
+  final jsonFile = await jsonFileFor(image, tryhard: tryHard);
+  if (jsonFile == null) return;
+
+  Map<String, dynamic> data;
+  try {
+    data = jsonDecode(await jsonFile.readAsString()) as Map<String, dynamic>;
+  } catch (_) {
+    return;
+  }
+
+  final gps = (data['geoDataExif'] ?? data['geoData'] ?? data['location']) as Map?;
+  if (gps == null) return;
+  final lat = _toDouble(gps['latitude']);
+  final lon = _toDouble(gps['longitude']);
+  if (lat == null || lon == null) return;
+
+  final bytes = await image.readAsBytes();
+  final img = decodeImage(bytes);
+  if (img == null) return;
+
+  img.exif ??= ExifData();
+  img.exif!.tags['GPSLatitude'] = _decimalToDms(lat);
+  img.exif!.tags['GPSLatitudeRef'] = lat >= 0 ? 'N' : 'S';
+  img.exif!.tags['GPSLongitude'] = _decimalToDms(lon);
+  img.exif!.tags['GPSLongitudeRef'] = lon >= 0 ? 'E' : 'W';
+
+  final encoded = encodeJpg(img, exif: img.exif);
+  await image.writeAsBytes(encoded);
+}
+
+/// Convert decimal coordinate to [Rational] list used by EXIF.
+List<Rational> _decimalToDms(double value) {
+  final deg = value.abs().floor();
+  final minFloat = (value.abs() - deg) * 60;
+  final min = minFloat.floor();
+  final sec = ((minFloat - min) * 60);
+  return [
+    Rational(deg, 1),
+    Rational(min, 1),
+    Rational((sec * 1000).round(), 1000),
+  ];
+}
+
+double? _toDouble(dynamic v) {
+  if (v == null) return null;
+  return double.tryParse(v.toString());
+}

--- a/lib/moving.dart
+++ b/lib/moving.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:gpth/interactive.dart' as interactive;
 import 'package:gpth/utils.dart';
+import 'package:gpth/gps_writer.dart';
 import 'package:path/path.dart' as p;
 
 import 'media.dart';
@@ -241,6 +242,12 @@ Stream<int> moveFiles(
         }
       } catch (e) {
         print("WARNING: Can't set modification time on $result: $e");
+      }
+
+      try {
+        await writeGpsFromJson(result);
+      } catch (e) {
+        print("WARNING: Can't write GPS data for $result: $e");
       }
 
       // one copy/move/whatever - one yield

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   fuzzysearch: ^0.1.3
   crypto: ^3.0.3
   exif: ^3.1.4
+  image: ^4.0.17
   console_bars: ^1.2.0
   file_picker_desktop: ^1.1.1
   #  archive:


### PR DESCRIPTION
## Summary
- add `gps_writer.dart` to write coordinates from sidecar JSON into image EXIF
- expose `jsonFileFor` helper and reuse in JSON extractor
- write GPS data on moved files
- mark TODO as done in README
- include `image` dependency in `pubspec.yaml`

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f3ebe5dd88326a5540c97907d080a